### PR TITLE
set to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ kubectl get clusterrolebindings -o json > clusterrolebindings.json
 ##  example & output:
 **Usage**
 ```
-python ExtensiveRoleCheck.py --clusterRole clusterroles.json  --role Roles.json --rolebindings rolebindings.json --cluseterolebindings clusterrolebindings.json
+python3 ExtensiveRoleCheck.py --clusterRole clusterroles.json  --role Roles.json --rolebindings rolebindings.json --cluseterolebindings clusterrolebindings.json
 ```
 ![Output example](https://github.com/cyberark/kubernetes-rbac-audit/blob/master/output-example.png)
 


### PR DESCRIPTION
python 2 gave me the following error:

```
  File "ExtensiveRoleCheck.py", line 24
    self._role_format = logging.Formatter(f'{Fore.YELLOW}[!][%(name)s]{Fore.WHITE}\u2192 %(message)s')
                                                                                                    ^
SyntaxError: invalid syntax
```

python3 worked