### PR TITLE
Fix null value in entity parsing

### DIFF
--- a/ExtensiveRoleCheck.py
+++ b/ExtensiveRoleCheck.py
@@ -43,6 +43,8 @@ class ExtensiveRolesChecker(object):
     def _generate(self):
         for entity in self._json_file['items']:
             role_name = entity['metadata']['name']
+            if entity['rules'] is None:
+                continue
             for rule in entity['rules']:
                 if not rule.get('resources', None):
                     continue


### PR DESCRIPTION
Added fix for when the rules dict value is "null". It will skip the entity then.

### Desired Outcome
If an entity has no rules attached, the script will fail as it does not count for "null" in the "rules" key.

### Implemented Changes
The entity is checked for the rules key value, if not existing, pass onto the next.